### PR TITLE
Add ColorPickerModal component to custom-components

### DIFF
--- a/src/custom-components/ColorPickerModal.tsx
+++ b/src/custom-components/ColorPickerModal.tsx
@@ -1,0 +1,163 @@
+import { gamepadSliderClasses, ModalRoot, SliderField } from "../deck-components";
+import { useState, VFC, CSSProperties } from "react";
+
+interface ColorPickerModalProps {
+  closeModal: () => void;
+  onConfirm?(HSLString: string): any;
+  title?: string;
+  defaultH?: number;
+  defaultS?: number;
+  defaultL?: number;
+  defaultA?: number;
+}
+
+export const ColorPickerModal: VFC<ColorPickerModalProps> = ({
+  closeModal,
+  onConfirm = () => {},
+  title = "Color Picker",
+  defaultH = 0,
+  defaultS = 100,
+  defaultL = 50,
+  defaultA = 1,
+}) => {
+  const [H, setH] = useState<number>(defaultH);
+  const [S, setS] = useState<number>(defaultS);
+  const [L, setL] = useState<number>(defaultL);
+  const [A, setA] = useState<number>(defaultA);
+
+  const colorPickerCSSVars = {
+    "--decky-color-picker-hvalue": `${H}`,
+    "--decky-color-picker-svalue": `${S}%`,
+    "--decky-color-picker-lvalue": `${L}%`,
+    "--decky-color-picker-avalue": `${A}`,
+  } as CSSProperties;
+
+  return (
+      <ModalRoot
+        bAllowFullSize
+        onCancel={closeModal}
+        onOK={() => {
+          onConfirm(`hsla(${H}, ${S}%, ${L}%, ${A})`);
+          closeModal();
+        }}
+      >
+        <style>
+        {`
+        /* This removes the cyan track color that is behind the slider head */
+        .ColorPicker_Container .${gamepadSliderClasses.SliderTrack} {
+          --left-track-color: #0000;
+          /* This is for compatibility with the "Colored Toggles" CSSLoader Theme*/
+          --colored-toggles-main-color: #0000;
+        }
+
+        .ColorPicker_HSlider .${gamepadSliderClasses.SliderTrack} {
+          background: linear-gradient(
+            270deg,
+            hsla(360, var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue)),
+            hsla(270, var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue)),
+            hsla(180, var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue)),
+            hsla(90, var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue)),
+            hsla(0, var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue))
+          );
+        }
+
+        .ColorPicker_SSlider .${gamepadSliderClasses.SliderTrack} {
+          background: linear-gradient(
+            90deg,
+            hsla(var(--decky-color-picker-hvalue), 0%, var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue)),
+            hsla(var(--decky-color-picker-hvalue), 100%, var(--decky-color-picker-lvalue), var(--decky-color-picker-avalue))
+          );
+        }
+
+        .ColorPicker_LSlider .${gamepadSliderClasses.SliderTrack} {
+          background: linear-gradient(
+            90deg,
+            hsla(var(--decky-color-picker-hvalue), var(--decky-color-picker-svalue), 0%, var(--decky-color-picker-avalue)),
+            hsla(var(--decky-color-picker-hvalue), var(--decky-color-picker-svalue), 50%, var(--decky-color-picker-avalue)),
+            hsla(var(--decky-color-picker-hvalue), var(--decky-color-picker-svalue), 100%, var(--decky-color-picker-avalue))
+          );
+        }
+
+        .ColorPicker_ASlider .${gamepadSliderClasses.SliderTrack} {
+          background: linear-gradient(
+            90deg,
+            hsla(var(--decky-color-picker-hvalue), var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), 0),
+            hsla(var(--decky-color-picker-hvalue), var(--decky-color-picker-svalue), var(--decky-color-picker-lvalue), 1)
+          );
+        }
+        `}
+      </style>
+        <div
+          className="ColorPicker_ColorDisplayContainer"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "1em",
+            // theres a large header by default on the modal, so this just pushes it up into that unused space
+            marginTop: "-2.5em",
+          }}
+        >
+          <div>
+            <span style={{ fontSize: "1.5em" }}>
+              <b>{title}</b>
+            </span>
+          </div>
+          <div
+            style={{
+              backgroundColor: `hsla(${H}, ${S}%, ${L}%, ${A})`,
+              width: "40px",
+              height: "40px",
+            }}
+          ></div>
+        </div>
+        <div className="ColorPicker_Container" style={colorPickerCSSVars}>
+          <div className="ColorPicker_HSlider">
+            <SliderField
+              showValue
+              editableValue
+              label="Hue"
+              value={H}
+              min={0}
+              max={360}
+              onChange={setH}
+            />
+          </div>
+          <div className="ColorPicker_SSlider">
+            <SliderField
+              showValue
+              editableValue
+              label="Saturation"
+              value={S}
+              min={0}
+              max={100}
+              onChange={setS}
+            />
+          </div>
+          <div className="ColorPicker_LSlider">
+            <SliderField
+              showValue
+              editableValue
+              label="Lightness"
+              value={L}
+              min={0}
+              max={100}
+              onChange={setL}
+            />
+          </div>
+          <div className="ColorPicker_ASlider">
+            <SliderField
+              showValue
+              editableValue
+              label="Alpha"
+              value={A}
+              step={0.1}
+              min={0}
+              max={1}
+              onChange={setA}
+            />
+          </div>
+        </div>
+      </ModalRoot>
+  );
+};

--- a/src/custom-components/index.ts
+++ b/src/custom-components/index.ts
@@ -1,1 +1,2 @@
 export * from './SuspensefulImage';
+export * from './ColorPickerModal';

--- a/src/deck-components/static-classes.ts
+++ b/src/deck-components/static-classes.ts
@@ -208,6 +208,53 @@ type UpdaterFieldClasses = Record<
   string
 >;
 
+type GamepadSliderClasses = Record<
+  | "error-shake-duration"
+  | "SliderControlPanelGroup"
+  | "SliderControlAndNotches"
+  | "WithDefaultValue"
+  | "SliderControl"
+  | "Disabled"
+  | "SliderTrack"
+  | "SliderHasNotches"
+  | "SliderTrackDark"
+  | "SliderHandleContainer"
+  | "VerticalLineSliderHandleContainer"
+  | "ParenSliderHandleContainer"
+  | "SliderHandle"
+  | "SliderHandleFocusPop"
+  | "VerticalLineSliderHandle"
+  | "ParenSliderHandle"
+  | "Left"
+  | "SliderControlWithIcon"
+  | "Icon"
+  | "SliderNotchContainer"
+  | "SliderNotch"
+  | "AlignToEnds"
+  | "SliderNotchLabel"
+  | "AlignToLeft"
+  | "AlignToRight"
+  | "SliderNotchTick"
+  | "TickActive"
+  | "LabelText"
+  | "DescriptionValue"
+  | "EditableValue"
+  | "FakeEditableValue"
+  | "RedBorder"
+  | "EditableValueSuffix"
+  | "ErrorShake"
+  | "error-shake"
+  | "CompoundSlider"
+  | "CompoundSliderSubSlider"
+  | "Right"
+  | "CompoundSliderSubSliderLabelContainer"
+  | "CompoundSliderSubSliderLabelPositioner"
+  | "CompoundSliderSubSliderLabel"
+  | "CompoundSliderSubSliderLabelInternal"
+  | "DefaultValueTickContainer"
+  | "DefaultValueTick",
+  string
+>;
 
 export const staticClasses: StaticClasses = findModule((mod) => {
   if (typeof mod !== 'object') return false;
@@ -253,6 +300,16 @@ export const updaterFieldClasses: UpdaterFieldClasses = findModule((mod) => {
   if (typeof mod !== 'object') return false;
 
   if (mod.PatchNotes && mod.PostedTime) {
+    return true;
+  }
+
+  return false;
+});
+
+export const gamepadSliderClasses: GamepadSliderClasses = findModule((mod) => {
+  if (typeof mod !== 'object') return false;
+
+  if (mod.SliderTrack) {
     return true;
   }
 


### PR DESCRIPTION
This was originally designed for the CSSLoader plugin to choose custom colours, but I modified it to be universal and expose all the necessary variables.

It must be wrapped in a showModal() as it inherits the closeModal property of that.
The other properties are: 

- `onConfirm(HSLString: string, closeModal: () => void): any;`, this is a function the user specifies that is given 2 parameters, the first being an HSL color string, and the second being the closeModal function.
- `title: string;`, this is the title that is shown in the Modal window.
- `defaultH: number;`, the starting hue value
- `defaultS: number;`, the starting saturation value
- `defaultL: number;`, the starting lightness value

All of these are in the interface for the component.

I was inspired to PR this because AAGaming asked me to add it, but I don't know too much about the inner workings of the decky-frontend-lib. I built the dist folder and everything worked perfectly, but if someone else could ensure it builds properly as well it would be greatly appreciated 😄 

![Image](https://i.imgur.com/H5U4Fwx.gif)