### PR TITLE
fix(Navigation): fix NavigateToExternalWeb and ModalRoot

### DIFF
--- a/src/deck-components/Modal.tsx
+++ b/src/deck-components/Modal.tsx
@@ -123,7 +123,7 @@ export const ModalRoot = (Object.values(
     if (typeof m !== 'object') return false;
 
     for (let prop in m) {
-      if (m[prop]?.m_mapModalManager) {
+      if (m[prop]?.m_mapModalManager && Object.values(m)?.find((x: any) => x?.type)) {
         return true;
       }
     }

--- a/src/deck-components/Router.tsx
+++ b/src/deck-components/Router.tsx
@@ -159,7 +159,7 @@ try {
         Router.WindowStore.GamepadUIMainWindowInstance,
       ),
       NavigateToAppProperties: InternalNavigators?.AppProperties || Router.NavigateToAppProperties.bind(Router),
-      NavigateToExternalWeb: Router.NavigateToExternalWeb.bind(Router),
+      NavigateToExternalWeb: InternalNavigators?.ExternalWeb || Router.NavigateToExternalWeb.bind(Router),
       NavigateToInvites: InternalNavigators?.Invites || Router.NavigateToInvites.bind(Router),
       NavigateToChat: Router.NavigateToChat.bind(Router),
       NavigateToLibraryTab: InternalNavigators?.LibraryTab || Router.NavigateToLibraryTab.bind(Router),


### PR DESCRIPTION
NavigateToExternalWeb was moved to InternalNavigators. This adds support for that while ||'ing the old implementation