### PR TITLE
Add support for SidebarNavigation separator

### DIFF
--- a/src/deck-components/SidebarNavigation.tsx
+++ b/src/deck-components/SidebarNavigation.tsx
@@ -16,7 +16,7 @@ export interface SidebarNavigationPage {
 
 export interface SidebarNavigationProps {
   title?: string;
-  pages: SidebarNavigationPage[];
+  pages: (SidebarNavigationPage|string)[];
   showTitle?: boolean;
   disableRouteReporting?: boolean;
   page?: string;

--- a/src/deck-components/SidebarNavigation.tsx
+++ b/src/deck-components/SidebarNavigation.tsx
@@ -16,7 +16,7 @@ export interface SidebarNavigationPage {
 
 export interface SidebarNavigationProps {
   title?: string;
-  pages: (SidebarNavigationPage|string)[];
+  pages: (SidebarNavigationPage | 'separator')[];
   showTitle?: boolean;
   disableRouteReporting?: boolean;
   page?: string;


### PR DESCRIPTION
Looked into it and in order to render a separator you need to pass `"separator"`