### PR TITLE
fix: the typescript compiler was eating the enum

### DIFF
--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -57,7 +57,7 @@ export interface FilePickerRes {
   realpath: string;
 }
 
-export enum FileSelectionType {
+export const enum FileSelectionType {
   FILE,
   FOLDER,
 }


### PR DESCRIPTION
If not defined with a const keyword