### PR TITLE
feat(deck-components): add standalone slider component

### DIFF
--- a/src/deck-components/Slider.tsx
+++ b/src/deck-components/Slider.tsx
@@ -1,0 +1,32 @@
+import { CSSProperties, VFC } from 'react';
+import { findModuleChild } from '../webpack';
+import { NotchLabel } from './SliderField';
+
+export interface SliderProps {
+  value: number;
+  resetValue?: number;
+  disabled?: boolean;
+  min?: number;
+  max?: number;
+  clampMin?: boolean;
+  clampMax?: boolean;
+  notchCount?: number;
+  notchLabels?: NotchLabel[];
+  notchTicksVisible?: boolean;
+  dpadStep?: number;
+  onChange?: (value: number, sliderChangeSource?: number) => void;
+  onChangeStart?: (sliderChangeSource?: number) => void;
+  onChangeComplete?: (value: number, sliderChangeSource?: number) => void;
+  focusable?: boolean;
+  handleType?: 'leftparen' | 'rightparen' | 'verticalline';
+  navRef?: unknown; //nav node ref
+  trackStyleOverride?: CSSProperties;
+  trackTone?: 'dark';
+  showHandle?: boolean;
+  isKeyNavTarget?: boolean;
+}
+
+export const Slider: VFC<SliderProps> = findModuleChild((mod: any) => {
+  if (typeof mod !== 'object' || !mod.__esModule) return undefined;
+  return mod.GamepadSliderControl;
+});

--- a/src/deck-components/Slider.tsx
+++ b/src/deck-components/Slider.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, VFC } from 'react';
-import { findModuleChild } from '../webpack';
+import { CommonUIModule } from '../webpack';
 import { NotchLabel } from './SliderField';
 
 export interface SliderProps {
@@ -26,7 +26,7 @@ export interface SliderProps {
   isKeyNavTarget?: boolean;
 }
 
-export const Slider: VFC<SliderProps> = findModuleChild((mod: any) => {
-  if (typeof mod !== 'object' || !mod.__esModule) return undefined;
-  return mod.GamepadSliderControl;
-});
+export const Slider: VFC<SliderProps> = CommonUIModule.GamepadSliderControl ||
+  Object.values(CommonUIModule).find(
+    (mod: any) => mod?.prototype?.UpdateSliderValueForPosition
+  );

--- a/src/deck-components/index.ts
+++ b/src/deck-components/index.ts
@@ -26,6 +26,7 @@ export * from './Toggle';
 export * from './ToggleField';
 export * from './SteamClient';
 export * from './Scroll';
+export * from './Slider';
 
 import { AppDetails, LogoPosition, SteamAppOverview, SteamClient } from './SteamClient';
 


### PR DESCRIPTION
This is just the built in slider component. Note that this component does not give any indication of when it's focused, as that's normally indicated by the field.