### PR TITLE
Dropdown contextMenuPositionOptions prop definition

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -19,6 +19,11 @@ export interface MultiDropdownOption {
 
 export type DropdownOption = SingleDropdownOption | MultiDropdownOption;
 
+export interface DropdownMenuPositionOptions {
+  [_: string]: unknown
+  bMatchWidth?: boolean
+}
+
 export interface DropdownProps {
   rgOptions: DropdownOption[];
   selectedOption: any;
@@ -26,7 +31,7 @@ export interface DropdownProps {
   onMenuWillOpen?(showMenu: () => void): void;
   onMenuOpened?(): void;
   onChange?(data: SingleDropdownOption): void;
-  contextMenuPositionOptions?: any;
+  contextMenuPositionOptions?: DropdownMenuPositionOptions;
   menuLabel?: string;
   strDefaultLabel?: string;
   renderButtonValue?(element: ReactNode): ReactNode;


### PR DESCRIPTION
This is untested on Steam Deck, though seemingly all components function the same across platforms. 

`bMatchWidth` implicitly true, controls whether the opened Dropdown menu will match the width of the Dropdown component on the viewport. 

```js
 <Dropdown contextMenuPositionOptions={{bMatchWidth: false}}/>
```
![Screenshot 2024-05-11 004110](https://github.com/SteamDeckHomebrew/decky-frontend-lib/assets/81448108/70790ff7-5cf3-4b26-8f09-a6dacfbce418)

```js
 <Dropdown contextMenuPositionOptions={{bMatchWidth: true}}/>
```
![Screenshot 2024-05-11 003724](https://github.com/SteamDeckHomebrew/decky-frontend-lib/assets/81448108/6d14c2eb-f205-4805-b9e4-03a1815a31f5)

this could entirely be relative to `IN_CLIENT || IN_DECK` but I'm just throwing it out there in case
