### PR TITLE
Update release.yaml to use Node.js 18 as PNPM v9 requires Node.js 18 or higher.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup | Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Setup | Dependencies
         run: npm i -g pnpm && pnpm i --frozen-lockfile
       - name: Build


### PR DESCRIPTION
With the latest PNPM major release, version 9, Node.js v18+ is required to run any PNPM commands.

Having Node.js v16 fails the release Github action check as the Node.js version requirement is not met for running `pnpm` commands.