### PR TITLE
feat: add `MenuSeparator` component

### DIFF
--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -45,6 +45,10 @@ export const MenuItem: FC<MenuItemProps> = findModuleExport(
     e?.render?.toString?.()?.includes('bPlayAudio:') || (e?.prototype?.OnOKButton && e?.prototype?.OnMouseEnter),
 );
 
+export const MenuSeparator: FC = findModuleExport(
+  (e: Export) => typeof e === 'function' && /className:.+?\.ContextMenuSeparator/.test(e.toString()),
+);
+
 /*
 all().map(m => {
 if (typeof m !== "object") return undefined;


### PR DESCRIPTION
Extracted from this export:

```js
function x(e) {
    const t = o.useContext(k).styles ?? v();
    return o.createElement("div", {
        className: t.ContextMenuSeparator
    })
}
```

It can be used as a child of `Menu`, i.e. sibling to `MenuItem` (see arrows in screenshot).

![Screenshot](https://github.com/user-attachments/assets/a6be8770-291f-4ee3-ba69-db07e47aa16d)
