### PR TITLE
Fix class component patching with tree patcher

### DIFF
--- a/src/utils/react/treepatcher.ts
+++ b/src/utils/react/treepatcher.ts
@@ -23,11 +23,6 @@ function patchComponent(node: any, handler: GenericPatchHandler, steps: NodeStep
     // We need to take extra care to not mutate the original node.type
     switch (typeof node?.[prop]) {
         case 'function':
-            // Function component
-            const patch = afterPatch(node, prop, steps[step + 1] ? createStepHandler(handler, steps, step + 1, caches, logger) : handler);
-            loggingEnabled && logger.debug('Patched a function component', patch);
-            break;
-        case 'object':
             if (node[prop]?.prototype?.render) {
                 // Class component
                 // TODO handle patching custom methods
@@ -35,11 +30,16 @@ function patchComponent(node: any, handler: GenericPatchHandler, steps: NodeStep
                 const patch = afterPatch(node[prop].prototype, 'render', steps[step + 1] ? createStepHandler(handler, steps, step + 1, caches, logger) : handler);
                 loggingEnabled && logger.debug('Patched class component', patch);
             } else {
-                loggingEnabled && logger.debug('Patching forwardref/memo');
-                wrapReactType(node, prop);
-                // Step down the object
-                patchComponent(node[prop], handler, steps, step, caches, logger, node[prop]?.render ? 'render' : 'type'); 
+                // Function component
+                const patch = afterPatch(node, prop, steps[step + 1] ? createStepHandler(handler, steps, step + 1, caches, logger) : handler);
+                loggingEnabled && logger.debug('Patched a function component', patch);
             }
+            break;
+        case 'object':
+            loggingEnabled && logger.debug('Patching forwardref/memo');
+            wrapReactType(node, prop);
+            // Step down the object
+            patchComponent(node[prop], handler, steps, step, caches, logger, node[prop]?.render ? 'render' : 'type'); 
             break;
         default:
             logger.error('Unhandled component type', node);


### PR DESCRIPTION
The new tree patch expects the `node.type` of class components to be of type "object" however this is not the case.

An example class component node might look like 
```
{
    $$typeof:  Symbol(react.element)
    "key": null,
    "ref": null,
    "props": {},
    "type": class extends
    "_owner": null
}
```
Where `node.type` is a component class. Since classes in javascript classes are of type "function"
```jsx
class HelloWorld extends Component {
  render() {
    return <h1>Hello world!</h1>;
  }
}

assert(typeof HelloWorld === 'function')
```
the tree patcher fails to detect and wrap the class component.

An alternative fix could be to remove the switch and test the prototype first
```javascript
    if (node[prop]?.prototype?.render) {
        // Class component
        // TODO handle patching custom methods
        wrapReactClass(node);
        const patch = afterPatch(node[prop].prototype, 'render', steps[step + 1] ? createStepHandler(handler, steps, step + 1, caches, logger) : handler);
        loggingEnabled && logger.debug('Patched class component', patch);
    } else if (typeof node?.[prop] === 'object') {
        loggingEnabled && logger.debug('Patching forwardref/memo');
        wrapReactType(node, prop);
        // Step down the object
        patchComponent(node[prop], handler, steps, step, caches, logger, node[prop]?.render ? 'render' : 'type'); 
    } else {
        // Function component
        const patch = afterPatch(node, prop, steps[step + 1] ? createStepHandler(handler, steps, step + 1, caches, logger) : handler);
        loggingEnabled && logger.debug('Patched a function component', patch);
    }
```