### PR TITLE
fix: fix `<ConfirmModal />` for new Steam beta

### DIFF
--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -83,7 +83,7 @@ export interface ConfirmModalProps extends ModalRootProps {
 }
 
 export const ConfirmModal = findModuleExport(
-  (e: Export) => !e?.prototype?.OK && e?.prototype?.Cancel && e?.prototype?.render,
+  (e: Export) => e?.toString()?.includes('bUpdateDisabled') && e?.toString()?.includes('closeModal') && e?.toString()?.includes('onGamepadCancel'),
 ) as FC<ConfirmModalProps>;
 
 export const ModalRoot = Object.values(


### PR DESCRIPTION
## Summary
In the latest beta release `<ConfirmModal />` is now a functional component instead of a class component, so it no longer exposes `Cancel` or `render` from its prototype. 

## Note
The fix attached is backwards compatible and works for the current stable release, as well as the beta.
It is untested on the deck, but *is* tested on the client. 

